### PR TITLE
If repository has no annotated tags then fallback to revision for VERSION

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ function GitRevisionPlugin () {}
 
 GitRevisionPlugin.prototype.apply = function (compiler) {
   buildFile(compiler, 'git rev-parse HEAD', 'COMMITHASH')
-  buildFile(compiler, 'git describe', 'VERSION')
+  buildFile(compiler, 'git describe --always', 'VERSION')
 }
 
 module.exports = GitRevisionPlugin


### PR DESCRIPTION
The "git describe" command will fail if there are no annotated tags in
your repository. Use "git describe --always" instead which will fallback
to the revision in the case where there are no annotated tags