### PR TITLE
Fix issue caused by assuming webpack context would contain the git repo

### DIFF
--- a/fixtures/project/webpack.config.js
+++ b/fixtures/project/webpack.config.js
@@ -1,6 +1,3 @@
-var path = require('path')
-var GitRevisionPlugin = require(path.join(__dirname, '../../'))
-
 module.exports = {
   entry: './index.js',
 
@@ -16,9 +13,5 @@ module.exports = {
         loader: 'file?name=[name][git-revision-version].[ext]'
       }
     ]
-  },
-
-  plugins: [
-    new GitRevisionPlugin()
-  ]
+  }
 }

--- a/lib/build-file.js
+++ b/lib/build-file.js
@@ -2,18 +2,21 @@ var path = require('path')
 var exec = require('child_process').exec
 var removeEmptyLines = require('./helpers/remove-empty-lines.js')
 
-module.exports = function buildFile (compiler, command, replacePattern, asset) {
+module.exports = function buildFile (compiler, gitWorkTree, command, replacePattern, asset) {
   var data = ''
 
   compiler.plugin('compilation', function (compilation) {
-    var workTree = compilation.options.context
-    var gitDir = path.join(workTree, '.git')
-    var gitCommand = [
-      'git',
-      '--git-dir=' + gitDir,
-      '--work-tree=' + workTree,
-      command
-    ].join(' ')
+    var gitCommand = gitWorkTree
+      ? [
+        'git',
+        '--git-dir=' + path.join(gitWorkTree, '.git'),
+        '--work-tree=' + gitWorkTree,
+        command
+      ].join(' ')
+      : [
+        'git',
+        command
+      ].join(' ')
 
     compilation.plugin('optimize-tree', function (chunks, modules, callback) {
       exec(gitCommand, function (err, stdout) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,12 @@
 var buildFile = require('./build-file')
 
-function GitRevisionPlugin () {}
+function GitRevisionPlugin (options) {
+  this.gitWorkTree = options && options.gitWorkTree
+}
 
 GitRevisionPlugin.prototype.apply = function (compiler) {
-  buildFile(compiler, 'rev-parse HEAD', /\[git-revision-hash\]/gi, 'COMMITHASH')
-  buildFile(compiler, 'describe --always', /\[git-revision-version\]/gi, 'VERSION')
+  buildFile(compiler, this.gitWorkTree, 'rev-parse HEAD', /\[git-revision-hash\]/gi, 'COMMITHASH')
+  buildFile(compiler, this.gitWorkTree, 'describe --always', /\[git-revision-version\]/gi, 'VERSION')
 }
 
 module.exports = GitRevisionPlugin

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -4,6 +4,7 @@ var expect = require('chai').expect
 var webpack = require('webpack')
 var fs = require('fs-extra')
 var path = require('path')
+var GitRevisionPlugin = require('.')
 
 var sourceProject = path.join(__dirname, '../fixtures/project')
 var sourceGitRepository = path.join(__dirname, '../fixtures/git-repository')
@@ -28,6 +29,9 @@ describe('git-revision-webpack-plugin', function () {
 
     config.context = targetProject
     config.output.path = targetBuild
+    config.plugins = [
+      new GitRevisionPlugin({ gitWorkTree: targetProject })
+    ]
 
     webpack(config, function () {
       done()


### PR DESCRIPTION
That won’t necessarily be true, and most likely, won’t.

So fallback to use the working directory of the Node process by default and allow customising its location if needed via a `gitWorkTree` option.

This should fix:

```
        hash: childCompilation.hash,
                              ^

TypeError: Cannot read property 'hash' of undefined
``` 