### PR TITLE
Expose commithash and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,21 @@ module.exports = {
   }
 }
 ```
+
+### Public API
+
+The `VERSION` and `COMMITHASH` are also exposed through a public API.
+
+Example:
+
+```javascript
+var gitRevisionPlugin = new GitRevisionPlugin()
+module.exports = {
+  plugins: [
+    new DefinePlugin({
+      'VERSION': JSON.stringify(gitRevisionPlugin.version()),
+      'COMMITHASH': JSON.stringify(gitRevisionPlugin.commithash()),
+    })
+  ]
+}
+```

--- a/lib/build-file.js
+++ b/lib/build-file.js
@@ -1,27 +1,13 @@
-var path = require('path')
-var exec = require('child_process').exec
-var removeEmptyLines = require('./helpers/remove-empty-lines.js')
+var runGitCommand = require('./helpers/run-git-command')
 
 module.exports = function buildFile (compiler, gitWorkTree, command, replacePattern, asset) {
   var data = ''
 
   compiler.plugin('compilation', function (compilation) {
-    var gitCommand = gitWorkTree
-      ? [
-        'git',
-        '--git-dir=' + path.join(gitWorkTree, '.git'),
-        '--work-tree=' + gitWorkTree,
-        command
-      ].join(' ')
-      : [
-        'git',
-        command
-      ].join(' ')
-
     compilation.plugin('optimize-tree', function (chunks, modules, callback) {
-      exec(gitCommand, function (err, stdout) {
+      runGitCommand(gitWorkTree, command, function (err, res) {
         if (err) { return callback(err) }
-        data = removeEmptyLines(stdout)
+        data = res
 
         callback()
       })

--- a/lib/helpers/run-git-command.js
+++ b/lib/helpers/run-git-command.js
@@ -1,0 +1,27 @@
+var exec = require('child_process').exec
+var execSync = require('child_process').execSync
+var path = require('path')
+var removeEmptyLines = require('./remove-empty-lines')
+
+module.exports = function (gitWorkTree, command, callback) {
+  var gitCommand = gitWorkTree
+    ? [
+      'git',
+      '--git-dir=' + path.join(gitWorkTree, '.git'),
+      '--work-tree=' + gitWorkTree,
+      command
+    ].join(' ')
+    : [
+      'git',
+      command
+    ].join(' ')
+
+  if (callback) {
+    exec(gitCommand, function (err, stdout) {
+      if (err) { return callback(err) }
+      callback(null, removeEmptyLines(stdout))
+    })
+  } else {
+    return removeEmptyLines('' + execSync(gitCommand))
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,24 @@
 var buildFile = require('./build-file')
+var runGitCommand = require('./helpers/run-git-command')
+
+var commithashCommand = 'rev-parse HEAD'
+var versionCommand = 'describe --always'
 
 function GitRevisionPlugin (options) {
   this.gitWorkTree = options && options.gitWorkTree
 }
 
 GitRevisionPlugin.prototype.apply = function (compiler) {
-  buildFile(compiler, this.gitWorkTree, 'rev-parse HEAD', /\[git-revision-hash\]/gi, 'COMMITHASH')
-  buildFile(compiler, this.gitWorkTree, 'describe --always', /\[git-revision-version\]/gi, 'VERSION')
+  buildFile(compiler, this.gitWorkTree, commithashCommand, /\[git-revision-hash\]/gi, 'COMMITHASH')
+  buildFile(compiler, this.gitWorkTree, versionCommand, /\[git-revision-version\]/gi, 'VERSION')
+}
+
+GitRevisionPlugin.prototype.commithash = function (callback) {
+  return runGitCommand(this.gitWorkTree, commithashCommand)
+}
+
+GitRevisionPlugin.prototype.version = function (callback) {
+  return runGitCommand(this.gitWorkTree, versionCommand)
 }
 
 module.exports = GitRevisionPlugin

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -67,4 +67,16 @@ describe('git-revision-webpack-plugin', function () {
       expect(mainJs.indexOf(expectedPublicPath) !== -1).to.eql(true)
     })
   })
+
+  describe('public API', () => {
+    it('should expose the commithash', () => {
+      var plugin = new GitRevisionPlugin({ gitWorkTree: targetProject })
+      expect(plugin.commithash()).to.eql('10e1ff4c17ad1f12241b5c4d9a708a76e98289d8')
+    })
+
+    it('should expose the version', () => {
+      var plugin = new GitRevisionPlugin({ gitWorkTree: targetProject })
+      expect(plugin.version()).to.eql('v1.0.0')
+    })
+  })
 })


### PR DESCRIPTION
This lets you use the commithash and version for whatever you need, for example, adding it as a constant in your source files during build time.