### PR TITLE
Add branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ And a `COMMITHASH` such as:
 7c16d8b1abeced419c14eb9908baeb4229ac0542
 ```
 
+And with the branch option enabled a `BRANCH` such as:
+
+```
+master
+```
+
 ## Configuration
 
 The plugin requires no configuration by default, but it is possible to configure it to support custom git workflows.
@@ -55,6 +61,22 @@ module.exports = {
   plugins: [
     new GitRevisionPlugin({
       lightweightTags: true
+    })
+  ]
+}
+```
+
+### `branch: false`
+
+If you need branch name support, you may turn on `branch` option in this way:
+
+```javascript
+var GitRevisionPlugin = require('git-revision-webpack-plugin')
+
+module.exports = {
+  plugins: [
+    new GitRevisionPlugin({
+      branch: true
     })
   ]
 }
@@ -92,12 +114,29 @@ module.exports = {
 }
 ```
 
+### `branchCommand: 'rev-parse --abbrev-ref HEAD'`
+
+To change the default `git` command used to read the value of `BRANCH`:
+
+```javascript
+var GitRevisionPlugin = require('git-revision-webpack-plugin')
+
+module.exports = {
+  plugins: [
+    new GitRevisionPlugin({
+      branchCommand: 'git rev-parse --symbolic-full-name HEAD'
+    })
+  ]
+}
+```
+
 ## Path Substitutions
 
 It is also possible to use two [path substituitions](http://webpack.github.io/docs/configuration.html#output-filename) on build to get either the revision or version as part of output paths.
 
 - `[git-revision-version]`
 - `[git-revision-hash]`
+- `[git-revision-branch]` (only with the branch option enabled)
 
 Example:
 
@@ -112,7 +151,7 @@ module.exports = {
 
 ## Plugin API
 
-The `VERSION` and `COMMITHASH` are also exposed through a public API.
+The `VERSION`, `COMMITHASH` and `BRANCH` are also exposed through a public API.
 
 Example using the [DefinePlugin](http://webpack.github.io/docs/list-of-plugins.html#defineplugin):
 
@@ -124,6 +163,7 @@ module.exports = {
     new DefinePlugin({
       'VERSION': JSON.stringify(gitRevisionPlugin.version()),
       'COMMITHASH': JSON.stringify(gitRevisionPlugin.commithash()),
+      'BRANCH': JSON.stringify(gitRevisionPlugin.branch()),
     })
   ]
 }

--- a/fixtures/project/webpack.config.js
+++ b/fixtures/project/webpack.config.js
@@ -2,15 +2,15 @@ module.exports = {
   entry: './index.js',
 
   output: {
-    publicPath: 'http://cdn.com/assets/[git-revision-version]/[git-revision-hash]',
-    filename: '[name]-[git-revision-version].js'
+    publicPath: 'http://cdn.com/assets/[git-revision-branch]/[git-revision-version]/[git-revision-hash]',
+    filename: '[name]-[git-revision-branch]-[git-revision-version].js'
   },
 
   module: {
     loaders: [
       {
         test: /\.(txt)$/,
-        loader: 'file?name=[name][git-revision-version].[ext]'
+        loader: 'file?name=[name]-[git-revision-branch]-[git-revision-version].[ext]'
       }
     ]
   }

--- a/lib/index.integration.spec.js
+++ b/lib/index.integration.spec.js
@@ -52,17 +52,24 @@ describe('git-revision-webpack-plugin (integration)', function () {
     expect(COMMITHASH.toString()).to.eql('9a15b3ba1f8c347f9db94bcfde9630ed4fdeb1b2')
   })
 
-  describe('[git-revision-version] and [git-revision-hash] templates', function () {
+  it('should create the BRANCH file', function () {
+    var branchPath = path.join(targetBuild, 'BRANCH')
+    var BRANCH = fs.readFileSync(branchPath)
+
+    expect(BRANCH.toString()).to.eql('master')
+  })
+
+  describe('[git-revision-version], [git-revision-hash] and [git-revision-branch] templates', function () {
     it('should support templates in the output.filename', function () {
-      var versionPath = path.join(targetBuild, 'main-v1.0.0-1-g9a15b3b.js')
+      var versionPath = path.join(targetBuild, 'main-master-v1.0.0-1-g9a15b3b.js')
       fs.readFileSync(versionPath)
     })
 
     it('should support setting the public path', function () {
-      var versionPath = path.join(targetBuild, 'main-v1.0.0-1-g9a15b3b.js')
+      var versionPath = path.join(targetBuild, 'main-master-v1.0.0-1-g9a15b3b.js')
       var mainJs = fs.readFileSync(versionPath)
 
-      var expectedPublicPath = '__webpack_require__.p = "http://cdn.com/assets/v1.0.0-1-g9a15b3b/9a15b3ba1f8c347f9db94bcfde9630ed4fdeb1b2";'
+      var expectedPublicPath = '__webpack_require__.p = "http://cdn.com/assets/master/v1.0.0-1-g9a15b3b/9a15b3ba1f8c347f9db94bcfde9630ed4fdeb1b2";'
 
       expect(mainJs.indexOf(expectedPublicPath) !== -1).to.eql(true)
     })
@@ -77,6 +84,11 @@ describe('git-revision-webpack-plugin (integration)', function () {
     it('should expose the version', () => {
       var plugin = new GitRevisionPlugin({ gitWorkTree: targetProject })
       expect(plugin.version()).to.eql('v1.0.0-1-g9a15b3b')
+    })
+
+    it('should expose the branch', () => {
+      var plugin = new GitRevisionPlugin({ gitWorkTree: targetProject })
+      expect(plugin.branch()).to.eql('master')
     })
   })
 })
@@ -118,17 +130,24 @@ describe('git-revision-webpack-plugin with lightweightTags option', function () 
     expect(COMMITHASH.toString()).to.eql('9a15b3ba1f8c347f9db94bcfde9630ed4fdeb1b2')
   })
 
-  describe('[git-revision-version] and [git-revision-hash] templates', function () {
+  it('should create the BRANCH file', function () {
+    var branchPath = path.join(targetBuild, 'BRANCH')
+    var BRANCH = fs.readFileSync(branchPath)
+
+    expect(BRANCH.toString()).to.eql('master')
+  })
+
+  describe('[git-revision-version], [git-revision-hash] and [git-revision-branch] templates', function () {
     it('should support templates in the output.filename', function () {
-      var versionPath = path.join(targetBuild, 'main-v2.0.0-beta.js')
+      var versionPath = path.join(targetBuild, 'main-master-v2.0.0-beta.js')
       fs.readFileSync(versionPath)
     })
 
     it('should support setting the public path', function () {
-      var versionPath = path.join(targetBuild, 'main-v2.0.0-beta.js')
+      var versionPath = path.join(targetBuild, 'main-master-v2.0.0-beta.js')
       var mainJs = fs.readFileSync(versionPath)
 
-      var expectedPublicPath = '__webpack_require__.p = "http://cdn.com/assets/v2.0.0-beta/9a15b3ba1f8c347f9db94bcfde9630ed4fdeb1b2";'
+      var expectedPublicPath = '__webpack_require__.p = "http://cdn.com/assets/master/v2.0.0-beta/9a15b3ba1f8c347f9db94bcfde9630ed4fdeb1b2";'
 
       expect(mainJs.indexOf(expectedPublicPath) !== -1).to.eql(true)
     })
@@ -144,6 +163,10 @@ describe('git-revision-webpack-plugin with lightweightTags option', function () 
       var plugin = new GitRevisionPlugin({ gitWorkTree: targetProject, lightweightTags: true })
       expect(plugin.version()).to.eql('v2.0.0-beta')
     })
+
+    it('should expose the branch', () => {
+      var plugin = new GitRevisionPlugin({ gitWorkTree: targetProject, lightweightTags: true })
+      expect(plugin.branch()).to.eql('master')
+    })
   })
 })
-

--- a/lib/index.integration.spec.js
+++ b/lib/index.integration.spec.js
@@ -30,7 +30,10 @@ describe('git-revision-webpack-plugin (integration)', function () {
     config.context = targetProject
     config.output.path = targetBuild
     config.plugins = [
-      new GitRevisionPlugin({ gitWorkTree: targetProject })
+      new GitRevisionPlugin({
+        gitWorkTree: targetProject,
+        branch: true
+      })
     ]
 
     webpack(config, function () {
@@ -108,7 +111,11 @@ describe('git-revision-webpack-plugin with lightweightTags option', function () 
     config.context = targetProject
     config.output.path = targetBuild
     config.plugins = [
-      new GitRevisionPlugin({ gitWorkTree: targetProject, lightweightTags: true })
+      new GitRevisionPlugin({
+        gitWorkTree: targetProject,
+        lightweightTags: true,
+        branch: true
+      })
     ]
 
     webpack(config, function () {
@@ -168,5 +175,50 @@ describe('git-revision-webpack-plugin with lightweightTags option', function () 
       var plugin = new GitRevisionPlugin({ gitWorkTree: targetProject, lightweightTags: true })
       expect(plugin.branch()).to.eql('master')
     })
+  })
+})
+
+describe('git-revision-webpack-plugin without branch option', function () {
+  beforeEach(function (done) {
+    fs.emptyDirSync(targetProject)
+    fs.copySync(sourceProject, targetProject)
+
+    fs.emptyDirSync(targetGitRepository)
+    fs.copySync(sourceGitRepository, targetGitRepository)
+
+    fs.remove(targetBuild)
+
+    var config = require(targetProjectConfig)
+
+    config.context = targetProject
+    config.output.path = targetBuild
+    config.plugins = [
+      new GitRevisionPlugin({
+        gitWorkTree: targetProject
+      })
+    ]
+
+    webpack(config, function () {
+      done()
+    })
+  })
+
+  it('should create the VERSION file', function () {
+    var versionPath = path.join(targetBuild, 'VERSION')
+    var VERSION = fs.readFileSync(versionPath)
+
+    expect(VERSION.toString()).to.eql('v1.0.0-1-g9a15b3b')
+  })
+
+  it('should create the COMMITHASH file', function () {
+    var versionPath = path.join(targetBuild, 'COMMITHASH')
+    var COMMITHASH = fs.readFileSync(versionPath)
+
+    expect(COMMITHASH.toString()).to.eql('9a15b3ba1f8c347f9db94bcfde9630ed4fdeb1b2')
+  })
+
+  it('should not create the BRANCH file', function () {
+    var branchPath = path.join(targetBuild, 'BRANCH')
+    expect(fs.existsSync(branchPath)).to.eql(false)
   })
 })

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ var runGitCommand = require('./helpers/run-git-command')
 
 var COMMITHASH_COMMAND = 'rev-parse HEAD'
 var VERSION_COMMAND = 'describe --always'
+var BRANCH_COMMAND = 'rev-parse --abbrev-ref HEAD'
 
 function GitRevisionPlugin (options) {
   options = options || {}
@@ -14,6 +15,9 @@ function GitRevisionPlugin (options) {
 
   this.versionCommand = options.versionCommand ||
     VERSION_COMMAND + (options.lightweightTags ? ' --tags' : '')
+
+  this.branchCommand = options.branchCommand ||
+    BRANCH_COMMAND
 
   if (options.versionCommand && options.lightweightTags) {
     throw new Error('lightweightTags can\'t be used together versionCommand')
@@ -36,6 +40,14 @@ GitRevisionPlugin.prototype.apply = function (compiler) {
     /\[git-revision-version\]/gi,
     'VERSION'
   )
+
+  buildFile(
+    compiler,
+    this.gitWorkTree,
+    this.branchCommand,
+    /\[git-revision-branch\]/gi,
+    'BRANCH'
+  )
 }
 
 GitRevisionPlugin.prototype.commithash = function () {
@@ -49,6 +61,13 @@ GitRevisionPlugin.prototype.version = function () {
   return runGitCommand(
     this.gitWorkTree,
     this.versionCommand
+  )
+}
+
+GitRevisionPlugin.prototype.branch = function () {
+  return runGitCommand(
+    this.gitWorkTree,
+    this.branchCommand
   )
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,8 @@ function GitRevisionPlugin (options) {
   this.versionCommand = options.versionCommand ||
     VERSION_COMMAND + (options.lightweightTags ? ' --tags' : '')
 
+  this.createBranchFile = options.branch || false
+
   this.branchCommand = options.branchCommand ||
     BRANCH_COMMAND
 
@@ -41,13 +43,15 @@ GitRevisionPlugin.prototype.apply = function (compiler) {
     'VERSION'
   )
 
-  buildFile(
-    compiler,
-    this.gitWorkTree,
-    this.branchCommand,
-    /\[git-revision-branch\]/gi,
-    'BRANCH'
-  )
+  if (this.createBranchFile) {
+    buildFile(
+      compiler,
+      this.gitWorkTree,
+      this.branchCommand,
+      /\[git-revision-branch\]/gi,
+      'BRANCH'
+    )
+  }
 }
 
 GitRevisionPlugin.prototype.commithash = function () {

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -72,4 +72,32 @@ describe('git-revision-webpack-plugin (unit)', function () {
       expect(runGitCommand.args[0][1]).to.eql('custom version command')
     })
   })
+
+  describe('on setting custom branch command', function () {
+    it('should run the build on .apply', function () {
+      var buildFile = sinon.spy()
+      GitRevisionPlugin.__set__('buildFile', buildFile)
+
+      new GitRevisionPlugin({
+        branchCommand: 'custom branch command'
+      }).apply()
+
+      var branchCall = buildFile.args.find(function (calls) {
+        return calls[4] === 'BRANCH'
+      })
+
+      expect(branchCall[2]).to.eql('custom branch command')
+    })
+
+    it('should run the custom git command on .version', function () {
+      var runGitCommand = sinon.spy()
+      GitRevisionPlugin.__set__('runGitCommand', runGitCommand)
+
+      new GitRevisionPlugin({
+        branchCommand: 'custom branch command'
+      }).branch()
+
+      expect(runGitCommand.args[0][1]).to.eql('custom branch command')
+    })
+  })
 })

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -79,6 +79,7 @@ describe('git-revision-webpack-plugin (unit)', function () {
       GitRevisionPlugin.__set__('buildFile', buildFile)
 
       new GitRevisionPlugin({
+        branch: true,
         branchCommand: 'custom branch command'
       }).apply()
 
@@ -94,6 +95,7 @@ describe('git-revision-webpack-plugin (unit)', function () {
       GitRevisionPlugin.__set__('runGitCommand', runGitCommand)
 
       new GitRevisionPlugin({
+        branch: true,
         branchCommand: 'custom branch command'
       }).branch()
 


### PR DESCRIPTION
This fixes #11 Add branch name.

For our projects the branch name is very important.

> So, in the spirit of keeping this plugin slim, would it make sense for you to achieve your use case by using the DefinePlugin directly to make the information available at build time?

Using the DefinePlugin directly would force us to duplicate parts of your nice plugin. 
