### PR TITLE
Added support for an output path prefix option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,19 @@ module.exports = {
   ]
 }
 ```
+
+### `path: 'path/to/files'`
+
+To change the output path of the `VERSION`, `COMMITHASH`, and `BRANCH` files (relative to Webpack's [`output.path`](https://webpack.js.org/configuration/output/#output-path) setting):
+
+```javascript
+var GitRevisionPlugin = require('git-revision-webpack-plugin')
+
+module.exports = {
+  plugins: [
+    new GitRevisionPlugin({
+      path: 'common'
+    })
+  ]
+}
+```

--- a/lib/index.integration.spec.js
+++ b/lib/index.integration.spec.js
@@ -222,3 +222,52 @@ describe('git-revision-webpack-plugin without branch option', function () {
     expect(fs.existsSync(branchPath)).to.eql(false)
   })
 })
+
+describe('git-revision-webpack-plugin with path option', function () {
+  beforeEach(function (done) {
+    fs.emptyDirSync(targetProject)
+    fs.copySync(sourceProject, targetProject)
+
+    fs.emptyDirSync(targetGitRepository)
+    fs.copySync(sourceGitRepository, targetGitRepository)
+
+    fs.remove(targetBuild)
+
+    var config = require(targetProjectConfig)
+
+    config.context = targetProject
+    config.output.path = targetBuild
+    config.plugins = [
+      new GitRevisionPlugin({
+        gitWorkTree: targetProject,
+        branch: true,
+        path: 'path-a/path-b'
+      })
+    ]
+
+    webpack(config, function () {
+      done()
+    })
+  })
+
+  it('should create the VERSION file', function () {
+    var versionPath = path.join(targetBuild, 'path-a/path-b/VERSION')
+    var VERSION = fs.readFileSync(versionPath)
+
+    expect(VERSION.toString()).to.eql('v1.0.0-1-g9a15b3b')
+  })
+
+  it('should create the COMMITHASH file', function () {
+    var versionPath = path.join(targetBuild, 'path-a/path-b/COMMITHASH')
+    var COMMITHASH = fs.readFileSync(versionPath)
+
+    expect(COMMITHASH.toString()).to.eql('9a15b3ba1f8c347f9db94bcfde9630ed4fdeb1b2')
+  })
+
+  it('should create the BRANCH file', function () {
+    var branchPath = path.join(targetBuild, 'path-a/path-b/BRANCH')
+    var BRANCH = fs.readFileSync(branchPath)
+
+    expect(BRANCH.toString()).to.eql('master')
+  })
+})

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 var buildFile = require('./build-file')
+var path = require('path')
 var runGitCommand = require('./helpers/run-git-command')
 
 var COMMITHASH_COMMAND = 'rev-parse HEAD'
@@ -9,6 +10,7 @@ function GitRevisionPlugin (options) {
   options = options || {}
 
   this.gitWorkTree = options.gitWorkTree
+  this.path = options.path || ''
 
   this.commithashCommand = options.commithashCommand ||
     COMMITHASH_COMMAND
@@ -32,7 +34,7 @@ GitRevisionPlugin.prototype.apply = function (compiler) {
     this.gitWorkTree,
     this.commithashCommand,
     /\[git-revision-hash\]/gi,
-    'COMMITHASH'
+    path.join(this.path, 'COMMITHASH')
   )
 
   buildFile(
@@ -40,7 +42,7 @@ GitRevisionPlugin.prototype.apply = function (compiler) {
     this.gitWorkTree,
     this.versionCommand,
     /\[git-revision-version\]/gi,
-    'VERSION'
+    path.join(this.path, 'VERSION')
   )
 
   if (this.createBranchFile) {
@@ -49,7 +51,7 @@ GitRevisionPlugin.prototype.apply = function (compiler) {
       this.gitWorkTree,
       this.branchCommand,
       /\[git-revision-branch\]/gi,
-      'BRANCH'
+      path.join(this.path, 'BRANCH')
     )
   }
 }


### PR DESCRIPTION
At my workplace, we use Webpack to produce "branded", or "skinned" applications, which dictates that we have a directory structure like so:

    root/            # (webpack output directory)
      ├ common/      # (common assets)
      │ ├ BRANCH
      │ ├ COMMITHASH
      │ ├ VERSION
      │ └ ...
      └ site/
        ├ site-a/    # (assets specific to "site-a")
        │ └ ...
        └ site-b/    # (assets specific to "site-b")
          └ ...

This PR adds support for a `path` option, which allows us to output the version files in a location that works with our directory structure.