### PR TITLE
Webpack 4 support 🚀

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
+  - "8"
+  - "9"
 # send builds to the container-based infrastructure
 sudo: false
 deploy:

--- a/fixtures/project/webpack.config.js
+++ b/fixtures/project/webpack.config.js
@@ -7,10 +7,17 @@ module.exports = {
   },
 
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.(txt)$/,
-        loader: 'file?name=[name]-[git-revision-branch]-[git-revision-version].[ext]'
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: '[name]-[git-revision-branch]-[git-revision-version].[ext]'
+            }
+          }
+        ]
       }
     ]
   }

--- a/lib/build-file.js
+++ b/lib/build-file.js
@@ -3,8 +3,8 @@ var runGitCommand = require('./helpers/run-git-command')
 module.exports = function buildFile (compiler, gitWorkTree, command, replacePattern, asset) {
   var data = ''
 
-  compiler.plugin('compilation', function (compilation) {
-    compilation.plugin('optimize-tree', function (chunks, modules, callback) {
+  compiler.hooks.compilation.tap('GitRevisionWebpackPlugin', function (compilation) {
+    compilation.hooks.optimizeTree.tapAsync('GitRevisionWebpackPlugin', function (chunks, modules, callback) {
       runGitCommand(gitWorkTree, command, function (err, res) {
         if (err) { return callback(err) }
         data = res
@@ -13,12 +13,12 @@ module.exports = function buildFile (compiler, gitWorkTree, command, replacePatt
       })
     })
 
-    compilation.mainTemplate.plugin('asset-path', function (path) {
+    compilation.mainTemplate.hooks.assetPath.tap('GitRevisionWebpackPlugin', function (path) {
       return path.replace(replacePattern, data)
     })
   })
 
-  compiler.plugin('emit', function (compilation, callback) {
+  compiler.hooks.emit.tapAsync('GitRevisionWebpackPlugin', function (compilation, callback) {
     compilation.assets[asset] = {
       source: function () {
         return data

--- a/lib/index.integration.spec.js
+++ b/lib/index.integration.spec.js
@@ -72,7 +72,7 @@ describe('git-revision-webpack-plugin (integration)', function () {
       var versionPath = path.join(targetBuild, 'main-master-v1.0.0-1-g9a15b3b.js')
       var mainJs = fs.readFileSync(versionPath)
 
-      var expectedPublicPath = '__webpack_require__.p = "http://cdn.com/assets/master/v1.0.0-1-g9a15b3b/9a15b3ba1f8c347f9db94bcfde9630ed4fdeb1b2";'
+      var expectedPublicPath = 'http://cdn.com/assets/master/v1.0.0-1-g9a15b3b/9a15b3ba1f8c347f9db94bcfde9630ed4fdeb1b2'
 
       expect(mainJs.indexOf(expectedPublicPath) !== -1).to.eql(true)
     })
@@ -154,7 +154,7 @@ describe('git-revision-webpack-plugin with lightweightTags option', function () 
       var versionPath = path.join(targetBuild, 'main-master-v2.0.0-beta.js')
       var mainJs = fs.readFileSync(versionPath)
 
-      var expectedPublicPath = '__webpack_require__.p = "http://cdn.com/assets/master/v2.0.0-beta/9a15b3ba1f8c347f9db94bcfde9630ed4fdeb1b2";'
+      var expectedPublicPath = 'http://cdn.com/assets/master/v2.0.0-beta/9a15b3ba1f8c347f9db94bcfde9630ed4fdeb1b2'
 
       expect(mainJs.indexOf(expectedPublicPath) !== -1).to.eql(true)
     })

--- a/package.json
+++ b/package.json
@@ -29,14 +29,17 @@
     "url": "https://github.com/pirelenito/git-revision-webpack-plugin/issues"
   },
   "homepage": "https://github.com/pirelenito/git-revision-webpack-plugin",
+  "peerDependency": {
+    "webpack": "^4.0.0"
+  },
   "devDependencies": {
     "chai": "^3.5.0",
-    "file-loader": "^0.8.5",
+    "file-loader": "^1.1.11",
     "fs-extra": "^0.30.0",
     "mocha": "^2.4.5",
     "rewire": "^2.5.2",
     "sinon": "^1.17.5",
     "standard": "^6.0.5",
-    "webpack": "^1.13.0"
+    "webpack": "^4.6.0"
   }
 }


### PR DESCRIPTION
- Use new hooks API
- Update Node versions in Travis (Node 4 is no longer supported in Webpack 4)
- Update tests

References:
- https://medium.com/@Uneducated/how-to-write-upgrade-your-webpack-plugin-for-adding-support-for-webpack-4-9e6f1ab81677
- https://webpack.js.org/api/compilation-hooks/
- https://github.com/pedoe/docker_compose/blob/836deafe8c026518602ebb52eca8557637fb9596/jenkins/jenkins_home/.cache/yarn/v1/npm-webpack-4.0.1-768d708beeca4c5f77f6c2d38a240fb6ff50ba5d/lib/TemplatedPathPlugin.js#L102