### PR TITLE
Fix webpack 5 deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ It is also possible to use [path substitutions](https://webpack.js.org/configura
 - `[git-revision-version]`
 - `[git-revision-hash]`
 - `[git-revision-branch]` (only [when branch is enabled](#branch-false))
-- `[git-revision-last-commit-datetime]`
 
 Example:
 
@@ -68,7 +67,7 @@ module.exports = {
 
 ## Plugin API
 
-The `VERSION`, `COMMITHASH`, `LASTCOMMITDATETIME` and `BRANCH` are also exposed through a public API.
+The `VERSION`, `COMMITHASH` and `BRANCH` are also exposed through a public API.
 
 Example using the [DefinePlugin](https://webpack.js.org/plugins/define-plugin/#usage):
 
@@ -84,7 +83,6 @@ module.exports = {
       'VERSION': JSON.stringify(gitRevisionPlugin.version()),
       'COMMITHASH': JSON.stringify(gitRevisionPlugin.commithash()),
       'BRANCH': JSON.stringify(gitRevisionPlugin.branch()),
-      'LASTCOMMITDATETIME': JSON.stringify(gitRevisionPlugin.lastcommitdatetime()),
     })
   ]
 }
@@ -175,24 +173,6 @@ module.exports = {
   plugins: [
     new GitRevisionPlugin({
       branchCommand: 'rev-parse --symbolic-full-name HEAD'
-    })
-  ]
-}
-```
-
-### `lastCommitDateTimeCommand: 'log -1 --format=%cI'`
-
-To change the default `git` command used to read the value of `LASTCOMMITDATETIME`.
-
-This configuration is not not meant to accept arbitrary user input and it is executed by the plugin without any sanitization.
-
-```javascript
-var GitRevisionPlugin = require('git-revision-webpack-plugin')
-
-module.exports = {
-  plugins: [
-    new GitRevisionPlugin({
-      branchCommand: 'log -1 --format=%ci'
     })
   ]
 }

--- a/lib/build-file.js
+++ b/lib/build-file.js
@@ -13,7 +13,7 @@ module.exports = ({ compiler, gitWorkTree, command, replacePattern, asset }) => 
       })
     })
 
-    compilation.mainTemplate.hooks.assetPath.tap('asset-path', (assetPath, chunkData) => {
+    compilation.hooks.assetPath.tap('asset-path', (assetPath, chunkData) => {
       return (typeof assetPath === 'function'
         ? assetPath(chunkData)
         : assetPath).replace(replacePattern, data)

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@ var runGitCommand = require('./helpers/run-git-command')
 var COMMITHASH_COMMAND = 'rev-parse HEAD'
 var VERSION_COMMAND = 'describe --always'
 var BRANCH_COMMAND = 'rev-parse --abbrev-ref HEAD'
-var LASTCOMMITDATETIME_COMMAND = 'log -1 --format=%cI'
 
 function GitRevisionPlugin (options) {
   options = options || {}
@@ -21,9 +20,6 @@ function GitRevisionPlugin (options) {
 
   this.branchCommand = options.branchCommand ||
     BRANCH_COMMAND
-
-  this.lastCommitDateTimeCommand = options.lastCommitDateTimeCommand ||
-    LASTCOMMITDATETIME_COMMAND
 
   if (options.versionCommand && options.lightweightTags) {
     throw new Error('lightweightTags can\'t be used together versionCommand')
@@ -45,14 +41,6 @@ GitRevisionPlugin.prototype.apply = function (compiler) {
     command: this.versionCommand,
     replacePattern: /\[git-revision-version\]/gi,
     asset: 'VERSION'
-  })
-
-  buildFile({
-    compiler: compiler,
-    gitWorkTree: this.gitWorkTree,
-    command: this.lastCommitDateTimeCommand,
-    replacePattern: /\[git-revision-last-commit-datetime\]/gi,
-    asset: 'LASTCOMMITDATETIME'
   })
 
   if (this.createBranchFile) {
@@ -84,13 +72,6 @@ GitRevisionPlugin.prototype.branch = function () {
   return runGitCommand(
     this.gitWorkTree,
     this.branchCommand
-  )
-}
-
-GitRevisionPlugin.prototype.lastcommitdatetime = function () {
-  return runGitCommand(
-    this.gitWorkTree,
-    this.lastCommitDateTimeCommand
   )
 }
 

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -102,32 +102,4 @@ describe('git-revision-webpack-plugin (unit)', function () {
       expect(runGitCommand.args[0][1]).to.eql('custom branch command')
     })
   })
-
-  describe('on setting custom last commit date time command', function () {
-    it('should run the build on .apply', function () {
-      var buildFile = sinon.spy()
-      GitRevisionPlugin.__set__('buildFile', buildFile)
-
-      new GitRevisionPlugin({
-        lastCommitDateTimeCommand: 'custom last commit date time command'
-      }).apply()
-
-      var lastCommitDateTimeCall = buildFile.args.find(function (calls) {
-        return calls[0].asset === 'LASTCOMMITDATETIME'
-      })
-
-      expect(lastCommitDateTimeCall[0].command).to.eql('custom last commit date time command')
-    })
-
-    it('should run the custom git command on .lastcommitdatetime', function () {
-      var runGitCommand = sinon.spy()
-      GitRevisionPlugin.__set__('runGitCommand', runGitCommand)
-
-      new GitRevisionPlugin({
-        lastCommitDateTimeCommand: 'custom last commit date time command'
-      }).lastcommitdatetime()
-
-      expect(runGitCommand.args[0][1]).to.eql('custom last commit date time command')
-    })
-  })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-revision-webpack-plugin",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Simple webpack plugin that generates VERSION and COMMITHASH files during build",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
After upgrading to webpack 5 I got the following deprecation warning:

```
(node:14132) [DEP_WEBPACK_MAIN_TEMPLATE_ASSET_PATH] DeprecationWarning: MainTemplate.hooks.assetPath is deprecated (use Compilation.hooks.assetPath instead)
    at /Users…/node_modules/git-revision-webpack-plugin/lib/build-file.js:16:46
```

This adjusts the plugin code to the new webpack APIs as per the warning.

Closes https://github.com/pirelenito/git-revision-webpack-plugin/issues/50

Note: I opened this PR against the `master` branch. It includes 2 commits from the `v3` branch that have apparently not been propagated to `master`. ✌️ 