### PR TITLE
Improve compatibility between CJS and ESM modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install --save-dev git-revision-webpack-plugin
 Then, simply configure it as a plugin in the webpack config:
 
 ```javascript
-var GitRevisionPlugin = require('git-revision-webpack-plugin')
+const { GitRevisionPlugin } = require('git-revision-webpack-plugin')
 
 module.exports = {
   plugins: [new GitRevisionPlugin()],
@@ -70,7 +70,7 @@ Example using the [DefinePlugin](https://webpack.js.org/plugins/define-plugin/#u
 
 ```javascript
 const webpack = require('webpack')
-const GitRevisionPlugin = require('git-revision-webpack-plugin')
+const { GitRevisionPlugin } = require('git-revision-webpack-plugin')
 const gitRevisionPlugin = new GitRevisionPlugin()
 
 module.exports = {
@@ -95,7 +95,7 @@ The plugin requires no configuration by default, but it is possible to configure
 If you need [lightweight tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging#_lightweight_tags) support, you may turn on `lightweightTags` option in this way:
 
 ```javascript
-var GitRevisionPlugin = require('git-revision-webpack-plugin')
+const { GitRevisionPlugin } = require('git-revision-webpack-plugin')
 
 module.exports = {
   plugins: [
@@ -111,7 +111,7 @@ module.exports = {
 If you need branch name support, you may turn on `branch` option in this way:
 
 ```javascript
-var GitRevisionPlugin = require('git-revision-webpack-plugin')
+const { GitRevisionPlugin } = require('git-revision-webpack-plugin')
 
 module.exports = {
   plugins: [
@@ -129,7 +129,7 @@ To change the default `git` command used to read the value of `COMMITHASH`.
 This configuration is not not meant to accept arbitrary user input and it is executed by the plugin without any sanitization.
 
 ```javascript
-var GitRevisionPlugin = require('git-revision-webpack-plugin')
+const { GitRevisionPlugin } = require('git-revision-webpack-plugin')
 
 module.exports = {
   plugins: [
@@ -147,7 +147,7 @@ To change the default `git` command used to read the value of `VERSION`.
 This configuration is not not meant to accept arbitrary user input and it is executed by the plugin without any sanitization.
 
 ```javascript
-var GitRevisionPlugin = require('git-revision-webpack-plugin')
+const { GitRevisionPlugin } = require('git-revision-webpack-plugin')
 
 module.exports = {
   plugins: [
@@ -165,7 +165,7 @@ To change the default `git` command used to read the value of `BRANCH`.
 This configuration is not not meant to accept arbitrary user input and it is executed by the plugin without any sanitization.
 
 ```javascript
-var GitRevisionPlugin = require('git-revision-webpack-plugin')
+const { GitRevisionPlugin } = require('git-revision-webpack-plugin')
 
 module.exports = {
   plugins: [
@@ -183,7 +183,7 @@ To change the default `git` command used to read the value of `LASTCOMMITDATETIM
 This configuration is not not meant to accept arbitrary user input and it is executed by the plugin without any sanitization.
 
 ```javascript
-var GitRevisionPlugin = require('git-revision-webpack-plugin')
+const { GitRevisionPlugin } = require('git-revision-webpack-plugin')
 
 module.exports = {
   plugins: [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "5.0.0-0",
+  "version": "5.0.0-1",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.1",
+  "version": "5.0.0-0",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ interface GitRevisionPluginOptions {
   lightweightTags?: boolean
 }
 
-export default class GitRevisionPlugin {
+export class GitRevisionPlugin {
   gitWorkTree?: string
   commithashCommand: string
   versionCommand: string

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -1,7 +1,7 @@
 import webpack from 'webpack'
 import fs from 'fs-extra'
 import path from 'path'
-import GitRevisionPlugin from '../src'
+import { GitRevisionPlugin } from '../src'
 
 const sourceProject = path.join(__dirname, '../fixtures/project')
 const sourceGitRepository = path.join(__dirname, '../fixtures/git-repository')

--- a/test/unit.spec.ts
+++ b/test/unit.spec.ts
@@ -1,5 +1,5 @@
 import { Compiler } from 'webpack'
-import GitRevisionPlugin from '../src'
+import { GitRevisionPlugin } from '../src'
 
 jest.mock('../src/build-file', () => jest.fn())
 // eslint-disable-next-line import/first


### PR DESCRIPTION
Changes how we export the library to rely in named exports.

This is a breaking change and will be released as a major version bump.

The change to consumers will be that instead of requiring via:

```js
const GitRevisionPlugin = require('git-revision-webpack-plugin')
```

It should be via:

```js
const { GitRevisionPlugin } = require('git-revision-webpack-plugin')
```

This is a fix for #66 